### PR TITLE
Performance improvements and bug fixes

### DIFF
--- a/AtomicJS/dist/atomic.js
+++ b/AtomicJS/dist/atomic.js
@@ -2779,7 +2779,6 @@
     Object.defineProperty(stringLiteralTokenizer, "prototype", {value: Object.create(tokenizer.prototype)});
     function wordTokenizer()
     {
-        var firstLetterCharacters   = /[a-zA-Z_$]/;
         var wordCharacters          = /[a-zA-Z0-9_\-$]/;
         var priv                    =
         {
@@ -2790,16 +2789,11 @@
         function read(currentChar)
         {
             var handled = false;
-            if (!prot.isClosed && wordCharacters.test(currentChar))
+            if (wordCharacters.test(currentChar))
             {
+                if (prot.isClosed)  prot.isClosed   = false;
                 priv.value  += currentChar;
                 handled     = true;
-            }
-            else if (prot.isClosed && firstLetterCharacters.test(currentChar))
-            {
-                prot.isClosed   = false;
-                priv.value      = currentChar;
-                handled         = true;
             }
             return handled;
         }
@@ -3139,8 +3133,8 @@
                 new stringLiteralTokenizer("'", true),
                 new stringLiteralTokenizer("\"", true),
                 new stringLiteralTokenizer("`", false),
-                new wordTokenizer(),
                 new numeralTokenizer(),
+                new wordTokenizer(),
                 new delimiterTokenizer('.', propertyDelimiter),
                 new operatorTokenizer("...", ROOTDIRECTIVE),
                 new delimiterTokenizer('[', openKeyDelimiter),
@@ -3396,7 +3390,7 @@
                     var virtualProperty = {cachedValues: {}};
                     if (property.get !== undefined) virtualProperty.get = (function(basePath, key)
                     {
-                        var path = basePath + ((basePath||"").length > 0 && (key||"").length > 0 ? "[\'" : "") + key.replace("'", "\\'") + ((basePath||"").length > 0 && (key||"").length > 0 ? "']" : "");
+                        var path = basePath + ((basePath||"").length > 0 && (key||"").length > 0 ? "." : "") + key;
                         if (virtualProperty.cachedValues[path] === undefined)
                         {
                             virtualProperty.cachedValues[path]  = { listener: (function()

--- a/AtomicJS/dist/atomic.js
+++ b/AtomicJS/dist/atomic.js
@@ -3396,7 +3396,7 @@
                     var virtualProperty = {cachedValues: {}};
                     if (property.get !== undefined) virtualProperty.get = (function(basePath, key)
                     {
-                        var path = basePath + ((basePath||"").length > 0 && (key||"").length > 0 ? "." : "") + key;
+                        var path = basePath + ((basePath||"").length > 0 && (key||"").length > 0 ? "[\'" : "") + key.replace("'", "\\'") + ((basePath||"").length > 0 && (key||"").length > 0 ? "']" : "");
                         if (virtualProperty.cachedValues[path] === undefined)
                         {
                             virtualProperty.cachedValues[path]  = { listener: (function()

--- a/AtomicJS/dist/atomic.js
+++ b/AtomicJS/dist/atomic.js
@@ -904,8 +904,7 @@
     function forwardProperty(propertyKey, property)
     {
         var propertyValue   = property.property.call(this);
-        if (this.__customBind && propertyValue.isDataProperty)  this.__binder.defineDataProperties(this, propertyKey, {get: function(){return propertyValue();}, set: function(value){propertyValue(value);}, onchange: propertyValue.onchange});
-        else                                                    Object.defineProperty(this, propertyKey, {value: propertyValue, writable: !propertyValue.isDataProperty});
+        this.__binder.defineDataProperties(this, propertyKey, {get: function(){return propertyValue();}, set: function(value){propertyValue(value);}, onchange: propertyValue.onchange});
         
         if (property.value !== undefined)
         if (this[propertyKey].isDataProperty)   this[propertyKey](property.value);
@@ -4031,10 +4030,9 @@
                     }
                     if(options.onchange !== undefined)
                     {
-                        var onchangeKeys    = Object.keys(this.__onchange);
-                        reflect.deleteProperties(this.__onchange, onchangeKeys);
+                        reflect.deleteProperties(this.__onchange, Object.keys(this.__onchange));
 
-                        onchangeKeys       = Object.keys(options.onchange);
+                        var onchangeKeys    = Object.keys(options.onchange);
                         for(var counter2=0, onchangeKey;(onchangeKey=onchangeKeys[counter2]) !== undefined; counter2++)
                         {
                             var event   = options.onchange[onchangeKey];

--- a/AtomicJS/dist/atomic.js
+++ b/AtomicJS/dist/atomic.js
@@ -2780,7 +2780,7 @@
     function wordTokenizer()
     {
         var firstLetterCharacters   = /[a-zA-Z_$]/;
-        var wordCharacters          = /[a-zA-Z0-9_$]/;
+        var wordCharacters          = /[a-zA-Z0-9_\-$]/;
         var priv                    =
         {
             value:  ""

--- a/AtomicJS/dist/atomic.js
+++ b/AtomicJS/dist/atomic.js
@@ -692,7 +692,7 @@
             if (!silent)    notifyClassEvent.call(this, classNamesToRemove, false);
             return this;
         }},
-        scrollIntoView:     {value: function scrollIntoView()                                       { this.__element.scrollTop = 0; return this; }},
+        scrollIntoView:     {value: function scrollIntoView()                                       { if (this.__element.scrollIntoView) this.__element.scrollIntoView(); else this.__element.scrollTop = 0; return this; }},
         select:             {value: function select()                                               { selectContents(this.__element); return this; }},
         show:               {value: function show()                                                 { this.__setViewData("style.display", ""); this.triggerEvent("show"); return this; }},
         toggleClass:        {value: function toggleClass(className, condition, silent)              { if (condition === undefined) condition = !this.hasClass(className); return this[condition?"addClass":"removeClass"](className, silent); }},
@@ -2780,7 +2780,7 @@
     function wordTokenizer()
     {
         var firstLetterCharacters   = /[a-zA-Z_$]/;
-        var wordCharacters          = /[a-zA-Z0-9_\-$]/;
+        var wordCharacters          = /[a-zA-Z0-9_$]/;
         var priv                    =
         {
             value:  ""
@@ -3382,6 +3382,7 @@
             observe:            {value: function(path, peek){return this.__invoke(path, undefined, getObserverEnum.yes, peek);}},
             peek:               {value: function(path, unwrap){return this.__invoke(path, undefined, unwrap === true ? getObserverEnum.no : getObserverEnum.auto, true);}},
             read:               {value: function(path, peek){return this.__invoke(path, undefined, getObserverEnum.auto, peek);}},
+            toggle:             {value: function(path, value){this.setValue(path, this(path) == value ? undefined : value, false); }},
             unwrap:             {value: function(path){return this.__invoke(path, undefined, getObserverEnum.no, false);}},
             basePath:           {value: function(){return this.__basePath;}},
             shadows:            {get:   function(){return this.__bag.shadows;}},

--- a/AtomicJS/src/atomic/scripts/dataBinder.js
+++ b/AtomicJS/src/atomic/scripts/dataBinder.js
@@ -1,11 +1,8 @@
-!function(){"use strict";root.define("atomic.dataBinder", function dataBinder(each, removeItemFromArray, defineDataProperties)
+!function(){"use strict";root.define("atomic.dataBinder", function dataBinder(reflect, removeItemFromArray, defineDataProperties)
 {
     function notifyProperties()
     {
-        each(this.__properties,(function(property)
-        {
-            property.listen({bindPath: this.bindPath||"", data: this.data===undefined?null:this.data});
-        }).bind(this));
+        for(var counter=0,property;(property=this.__properties[counter]) !== undefined; counter++) property.listen({bindPath: this.bindPath||"", data: this.data===undefined?null:this.data});
     }
     function dataBinder(target, data)
     {
@@ -30,7 +27,7 @@
         {
             var debugInfo   = {};
             var hasBinding  = false;
-            each(this.__properties,(function(property)
+            for(var counter=0,property;(property=this.__properties[counter]) !== undefined; counter++)
             {
                 var debugBindPath   = property.__debugBindPath;
                 if (debugBindPath !== undefined)
@@ -38,7 +35,7 @@
                     hasBinding                  = true;
                     debugInfo[property.name]    = debugBindPath;
                 }
-            }).bind(this));
+            }
             return hasBinding ? debugInfo : undefined;
         }},
         __updateDebugInfo:      {value: function(){if (this.__target !== undefined) this.__target.__updateDebugInfo();}},
@@ -69,22 +66,18 @@
                 notifyProperties.call(this);
             }
         },
-        defineDataProperties:   {value: function (target, properties, singleProperty){defineDataProperties(target, this, properties, singleProperty);}},
-        destroy:                {value: function()
+        defineDataProperties:   {value: function $_defineDataProperties(target, properties, singleProperty){defineDataProperties(target, this, properties, singleProperty);}},
+        destroy:                {value: function destroy()
         {
-            each(this.__properties,(function(property){property.destroy();}).bind(this));
-            each
-            ([
+            Object.defineProperty(this, "__data", {value: undefined, configurable: true});
+            for(var counter=0,property;(property=this.__properties[counter]) !== undefined; counter++)  property.destroy();
+            reflect.deleteProperties(this,
+            [
                 "__properties",
                 "__forceRoot",
                 "__target",
                 "__data"
-            ],
-            (function(name)
-            {
-                Object.defineProperty(this, name, {value: null, configurable: true});
-                delete this[name];
-            }).bind(this));
+            ]);
             Object.defineProperty(this, "isDestroyed", {value: true});
         }},
         isBinder:               {value: true},

--- a/AtomicJS/src/atomic/scripts/dataPropertyFactory.js
+++ b/AtomicJS/src/atomic/scripts/dataPropertyFactory.js
@@ -189,10 +189,9 @@
                     }
                     if(options.onchange !== undefined)
                     {
-                        var onchangeKeys    = Object.keys(this.__onchange);
-                        reflect.deleteProperties(this.__onchange, onchangeKeys);
+                        reflect.deleteProperties(this.__onchange, Object.keys(this.__onchange));
 
-                        onchangeKeys       = Object.keys(options.onchange);
+                        var onchangeKeys    = Object.keys(options.onchange);
                         for(var counter2=0, onchangeKey;(onchangeKey=onchangeKeys[counter2]) !== undefined; counter2++)
                         {
                             var event   = options.onchange[onchangeKey];

--- a/AtomicJS/src/atomic/scripts/html/checkboxgroup.js
+++ b/AtomicJS/src/atomic/scripts/html/checkboxgroup.js
@@ -1,4 +1,4 @@
-!function(){"use strict";root.define("atomic.html.checkboxgroup", function htmlCheckboxGroup(input, dataBinder, each)
+!function(){"use strict";root.define("atomic.html.checkboxgroup", function htmlCheckboxGroup(input, dataBinder, reflect)
 {
     function setCheckboxGroupValues(values)
     {
@@ -113,7 +113,7 @@
         selectedIndex:      {get:   function(){ return this.__elements[0].selectedIndex; },   set: function(value){ this.__element.selectedIndex=value; this.getEvents("viewupdated").viewupdated(["selectedIndex"]); }},
         __isValueSelected:  {value: function(value){return Array.isArray(this.__rawValues) && this.__rawValues.indexOf(value) > -1;}}
     });
-    each(["text","value"], function(name)
+    function defineOptionMember(name)
     {
         var thisName    = name.substr(0,1).toUpperCase()+name.substr(1);
         Object.defineProperty(checkboxgroup.prototype, "option"+thisName, 
@@ -122,10 +122,12 @@
             set: function(value)
             {
                 Object.defineProperty(this,"__option"+thisName, {value: value, configurable: true});
-                each(this.__options, function(option){option[name].bind = value;});
+                for(var counter=0,option;(option=this.__options[counter]) !== undefined; counter++) option[name].bind = value;
             }
         });
-    });
+    }
+    defineOptionMember("text");
+    defineOptionMember("value");
     function clearCheckboxGroup(checkboxGroup){ for(var counter=checkboxGroup.childNodes.length-1;counter>=0;counter--) checkboxGroup.removeChild(checkboxGroup.childNodes[counter]); }
     function rebindCheckboxGroupSource(){bindCheckboxGroupSource.call(this, this.__boundItems);}
     function bindCheckboxGroupSource(items)

--- a/AtomicJS/src/atomic/scripts/html/composite.js
+++ b/AtomicJS/src/atomic/scripts/html/composite.js
@@ -1,4 +1,4 @@
-!function(){"use strict";root.define("atomic.html.composite", function htmlComposite(base, each, observer)
+!function(){"use strict";root.define("atomic.html.composite", function htmlComposite(base, reflect, observer)
 {
     function composite(elements, selector, parent, bindPath, childKey, protoChildKey)
     {

--- a/AtomicJS/src/atomic/scripts/html/compositionRoot.js
+++ b/AtomicJS/src/atomic/scripts/html/compositionRoot.js
@@ -1,16 +1,16 @@
 !function(){"use strict";root.define("atomic.html.compositionRoot", function htmlCompositionRoot(customizeControlTypes, debugInfoObserver)
 {
-    var each                    = root.utilities.each
+    var reflect                 = root.utilities.reflect;
     var isolatedFunctionFactory = new root.atomic.html.isolatedFunctionFactory(document);
     var pathParserFactory       = new root.atomic.pathParserFactory(new root.atomic.tokenizer());
     var pathParser              = new pathParserFactory.parser(new root.atomic.lexer(new root.atomic.scanner(), pathParserFactory.getTokenizers(), root.utilities.removeFromArray));
-    var observer                = new root.atomic.observerFactory(root.utilities.removeFromArray, isolatedFunctionFactory, each, pathParser);
+    var observer                = new root.atomic.observerFactory(root.utilities.removeFromArray, isolatedFunctionFactory, reflect, pathParser);
     if (debugInfoObserver === true) debugInfoObserver = new observer({__controlIndex:[], __controls:{}});
 
     var pubSub                  = new root.utilities.pubSub(isolatedFunctionFactory, root.utilities.removeItemFromArray);
-    var defineDataProperties    = new root.atomic.defineDataProperties(isolatedFunctionFactory, each, pubSub);
-    var dataBinder              = new root.atomic.dataBinder(each, root.utilities.removeItemFromArray, defineDataProperties);
-    var eventsSet               = new root.atomic.html.eventsSet(pubSub, each);
+    var defineDataProperties    = new root.atomic.defineDataProperties(isolatedFunctionFactory, reflect, pubSub);
+    var dataBinder              = new root.atomic.dataBinder(reflect, root.utilities.removeItemFromArray, defineDataProperties);
+    var eventsSet               = new root.atomic.html.eventsSet(pubSub, reflect);
     var controlTypes            = {};
     var viewAdapterFactory      =   new root.atomic.html.viewAdapterFactory
                                     (
@@ -18,26 +18,26 @@
                                         controlTypes,
                                         pubSub,
                                         function(message){console.log(message);},
-                                        each
+                                        reflect
                                     );
 
-    var control                 = new root.atomic.html.control(document, root.utilities.removeItemFromArray, window.setTimeout, each, eventsSet, dataBinder, debugInfoObserver);
-    var readonly                = new root.atomic.html.readonly(control, each);
-    var label                   = new root.atomic.html.label(readonly, each);
-    var link                    = new root.atomic.html.link(readonly, each);
-    var container               = new root.atomic.html.container(control, observer, each, viewAdapterFactory, root.utilities.removeItemFromArray);
-    var panel                   = new root.atomic.html.panel(container, each);
+    var control                 = new root.atomic.html.control(document, root.utilities.removeItemFromArray, window.setTimeout, reflect, eventsSet, dataBinder, debugInfoObserver);
+    var readonly                = new root.atomic.html.readonly(control, reflect);
+    var label                   = new root.atomic.html.label(readonly, reflect);
+    var link                    = new root.atomic.html.link(readonly, reflect);
+    var container               = new root.atomic.html.container(control, observer, reflect, viewAdapterFactory, root.utilities.removeItemFromArray);
+    var panel                   = new root.atomic.html.panel(container, reflect);
     var screen                  = new root.atomic.html.screen(panel, observer);
-    var linkPanel               = new root.atomic.html.link(panel, each);
-    var composite               = new root.atomic.html.composite(container, each);
+    var linkPanel               = new root.atomic.html.link(panel, reflect);
+    var composite               = new root.atomic.html.composite(container, reflect);
     var repeater                = new root.atomic.html.repeater(container, root.utilities.removeFromArray);
     var table                   = new root.atomic.html.table(container, root.utilities.removeFromArray);
     var input                   = new root.atomic.html.input(control);
     var checkbox                = new root.atomic.html.checkbox(control);
     var file                    = new root.atomic.html.file(control);
-    var select                  = new root.atomic.html.select(input, dataBinder, each);
-    var radiogroup              = new root.atomic.html.radiogroup(input, dataBinder, each);
-    var checkboxgroup           = new root.atomic.html.checkboxgroup(input, dataBinder, each);
+    var select                  = new root.atomic.html.select(input, dataBinder, reflect);
+    var radiogroup              = new root.atomic.html.radiogroup(input, dataBinder, reflect);
+    var checkboxgroup           = new root.atomic.html.checkboxgroup(input, dataBinder, reflect);
     var multiselect             = new root.atomic.html.multiselect(select);
     var image                   = new root.atomic.html.image(control);
     var audio                   = new root.atomic.html.audio(control);

--- a/AtomicJS/src/atomic/scripts/html/container.js
+++ b/AtomicJS/src/atomic/scripts/html/container.js
@@ -59,8 +59,7 @@
     function forwardProperty(propertyKey, property)
     {
         var propertyValue   = property.property.call(this);
-        if (this.__customBind && propertyValue.isDataProperty)  this.__binder.defineDataProperties(this, propertyKey, {get: function(){return propertyValue();}, set: function(value){propertyValue(value);}, onchange: propertyValue.onchange});
-        else                                                    Object.defineProperty(this, propertyKey, {value: propertyValue, writable: !propertyValue.isDataProperty});
+        this.__binder.defineDataProperties(this, propertyKey, {get: function(){return propertyValue();}, set: function(value){propertyValue(value);}, onchange: propertyValue.onchange});
         
         if (property.value !== undefined)
         if (this[propertyKey].isDataProperty)   this[propertyKey](property.value);

--- a/AtomicJS/src/atomic/scripts/html/control.js
+++ b/AtomicJS/src/atomic/scripts/html/control.js
@@ -466,7 +466,7 @@
             if (!silent)    notifyClassEvent.call(this, classNamesToRemove, false);
             return this;
         }},
-        scrollIntoView:     {value: function scrollIntoView()                                       { this.__element.scrollTop = 0; return this; }},
+        scrollIntoView:     {value: function scrollIntoView()                                       { if (this.__element.scrollIntoView) this.__element.scrollIntoView(); else this.__element.scrollTop = 0; return this; }},
         select:             {value: function select()                                               { selectContents(this.__element); return this; }},
         show:               {value: function show()                                                 { this.__setViewData("style.display", ""); this.triggerEvent("show"); return this; }},
         toggleClass:        {value: function toggleClass(className, condition, silent)              { if (condition === undefined) condition = !this.hasClass(className); return this[condition?"addClass":"removeClass"](className, silent); }},

--- a/AtomicJS/src/atomic/scripts/html/label.js
+++ b/AtomicJS/src/atomic/scripts/html/label.js
@@ -1,4 +1,4 @@
-!function(){"use strict";root.define("atomic.html.label", function htmlLabel(control, each)
+!function(){"use strict";root.define("atomic.html.label", function htmlLabel(control, reflect)
 {
     function label(elements, selector, parent, bindPath, childKey, protoChildKey)
     {
@@ -6,7 +6,7 @@
         Object.defineProperty(this, "__elements", {value: Array.prototype.slice.call(parent.__element.querySelectorAll(selector)), configurable: true});
         this.__binder.defineDataProperties(this,
         {
-            for:                {get: function(){return this.__element.getAttribute("for");},   set: function(value){each(this.__elements, function(element){element.setAttribute("for", value);}); this.__element.setAttribute("for", value); this.getEvents("viewupdated").viewupdated(["for"]);}}
+            for:                {get: function(){return this.__element.getAttribute("for");},   set: function(value){for(var counter=0,element; (element=this.__elements[counter])!==undefined; counter++) element.setAttribute("for", value); this.__element.setAttribute("for", value); this.getEvents("viewupdated").viewupdated(["for"]);}}
         });
     }
     Object.defineProperty(label, "prototype", {value: Object.create(control.prototype)});

--- a/AtomicJS/src/atomic/scripts/html/link.js
+++ b/AtomicJS/src/atomic/scripts/html/link.js
@@ -1,11 +1,11 @@
-!function(){"use strict";root.define("atomic.html.link", function htmlLink(base, each)
+!function(){"use strict";root.define("atomic.html.link", function htmlLink(base, reflect)
 {
     function link(elements, selector, parent, bindPath, childKey, protoChildKey)
     {
         base.call(this, elements, selector, parent, bindPath, childKey, protoChildKey);
         this.__binder.defineDataProperties(this,
         {
-            href: {get: function(){return this.__element.href;}, set: function(value){var val = value&&value.isObserver?value():value; each(this.__elements, function(element){element.href = val;}); this.__element.href = val; this.getEvents("viewupdated").viewupdated(["href"]);}}
+            href: {get: function(){return this.__element.href;}, set: function(value){var val = value&&value.isObserver?value():value; if(this.__elements !== undefined) for(var counter=0,element; (element=this.__elements[counter])!==undefined; counter++) element.href = val; this.__element.href = val; this.getEvents("viewupdated").viewupdated(["href"]);}}
         });
     }
     Object.defineProperty(link, "prototype", {value: Object.create(base.prototype)});

--- a/AtomicJS/src/atomic/scripts/html/panel.js
+++ b/AtomicJS/src/atomic/scripts/html/panel.js
@@ -1,4 +1,4 @@
-!function(){"use strict";root.define("atomic.html.panel", function htmlPanel(container, each)
+!function(){"use strict";root.define("atomic.html.panel", function htmlPanel(container, reflect)
 {
     function panel(elements, selector, parent, bindPath, childKey, protoChildKey)
     {

--- a/AtomicJS/src/atomic/scripts/html/radiogroup.js
+++ b/AtomicJS/src/atomic/scripts/html/radiogroup.js
@@ -1,4 +1,4 @@
-!function(){"use strict";root.define("atomic.html.radiogroup", function htmlRadioGroup(input, dataBinder, each)
+!function(){"use strict";root.define("atomic.html.radiogroup", function htmlRadioGroup(input, dataBinder, reflect)
 {
     function setOptionNames()
     {
@@ -114,7 +114,7 @@
         selectedIndex:      {get:   function(){ return this.__elements[0].selectedIndex; },   set: function(value){ this.__element.selectedIndex=value; this.getEvents("viewupdated").viewupdated(["selectedIndex"]); }},
         __isValueSelected:  {value: function(value){return this.__rawValue === value;}}
     });
-    each(["text","value"], function(name)
+    function defineOptionMember(name)
     {
         var thisName    = name.substr(0,1).toUpperCase()+name.substr(1);
         Object.defineProperty(radiogroup.prototype, "option"+thisName, 
@@ -123,10 +123,12 @@
             set: function(value)
             {
                 Object.defineProperty(this,"__option"+thisName, {value: value, configurable: true});
-                each(this.__options, function(option){option[name].bind = value;});
+                for(var counter=0,option;(option=this.__options[counter]) !== undefined; counter++) option[name].bind = value;
             }
         });
-    });
+    }
+    defineOptionMember("text");
+    defineOptionMember("value");
     function clearRadioGroup(radioGroup){ for(var counter=radioGroup.childNodes.length-1;counter>=0;counter--) radioGroup.removeChild(radioGroup.childNodes[counter]); }
     function clearRadioOptions(radioGroup){ for(var counter=radioGroup.__options.length-1;counter>=0;counter--) radioGroup.__setViewData("removeChild", radioGroup.__options[counter].__element); }
     function rebindRadioGroupSource(){bindRadioGroupSource.call(this, this.__boundItems);}

--- a/AtomicJS/src/atomic/scripts/html/readonly.js
+++ b/AtomicJS/src/atomic/scripts/html/readonly.js
@@ -1,4 +1,4 @@
-!function(){"use strict";root.define("atomic.html.readonly", function htmlReadOnly(control, each)
+!function(){"use strict";root.define("atomic.html.readonly", function htmlReadOnly(control, reflect)
 {
     function readonly(elements, selector, parent, bindPath, childKey, protoChildKey)
     {
@@ -24,10 +24,10 @@
                     }
                 }
             },
-            disabled:           {get: function(){return this.__element.disabled;},                  set: function(value){each(this.__elements, function(element){element.disabled = !(!value);}); this.__element.disabled=!(!value); this.getEvents("viewupdated").viewupdated(["disabled"]);}},
+            disabled:           {get: function(){return this.__element.disabled;},                  set: function(value){for(var counter=0,element; (element=this.__elements[counter])!==undefined; counter++) element.disabled = !(!value); this.__element.disabled=!(!value); this.getEvents("viewupdated").viewupdated(["disabled"]);}},
             display:            {get: function(){return this.__getViewData("styles.display")=="";}, set: function(value){this[value?"show":"hide"]();}},
-            enabled:            {get: function(){return !this.__element.disabled;},                 set: function(value){each(this.__elements, function(element){element.disabled = !value;}); this.__element.disabled=!value; this.getEvents("viewupdated").viewupdated(["disabled"]);}},
-            tooltip:            {get: function(){return this.__element.title;},                     set: function(value){var val = value&&value.isObserver?value():(value||""); each(this.__elements, function(element){element.title = val;}); this.__element.title = val; this.getEvents("viewupdated").viewupdated(["title"]);}},
+            enabled:            {get: function(){return !this.__element.disabled;},                 set: function(value){for(var counter=0,element; (element=this.__elements[counter])!==undefined; counter++) element.disabled = !value; this.__element.disabled=!value; this.getEvents("viewupdated").viewupdated(["disabled"]);}},
+            tooltip:            {get: function(){return this.__element.title;},                     set: function(value){var val = value&&value.isObserver?value():(value||""); for(var counter=0,element; (element=this.__elements[counter])!==undefined; counter++) element.title = val; this.__element.title = val; this.getEvents("viewupdated").viewupdated(["title"]);}},
             value:              {get: function(){return this.__getViewData("innerHTMLs");},         set: function(value){this.__setViewData("innerHTMLs", value);}}
         });
     }

--- a/AtomicJS/src/atomic/scripts/html/select.js
+++ b/AtomicJS/src/atomic/scripts/html/select.js
@@ -1,4 +1,4 @@
-!function(){"use strict";root.define("atomic.html.select", function htmlSelect(input, dataBinder, each)
+!function(){"use strict";root.define("atomic.html.select", function htmlSelect(input, dataBinder, reflect)
 {
     function getSelectListValue()
     {
@@ -39,16 +39,11 @@
         destroy:                {value: function()
         {
             this.__sourceBinder.destroy();
-            each
-            ([
+            reflect.deleteProperties(this,
+            [
                 "__element",
                 "__sourceBinder"
-            ],
-            (function(name)
-            {
-                Object.defineProperty(this, name, {value: null, configurable: true});
-                delete this[name];
-            }).bind(this));
+            ]);
             Object.defineProperty(this, "isDestroyed", {value: true});
         }},
     });
@@ -106,7 +101,7 @@
             input.prototype.destroy.call(this);
         }}
     });
-    each(["text","value"], function(name)
+    function defineOptionMember(name)
     {
         var thisName    = name.substr(0,1).toUpperCase()+name.substr(1);
         Object.defineProperty(select.prototype, "option"+thisName, 
@@ -115,10 +110,12 @@
             set: function(value)
             {
                 Object.defineProperty(this,"__option"+thisName, {value: value, configurable: true});
-                each(this.__options, function(option){option[name].bind = value;});
+                for(var counter=0,option;(option=this.__options[counter]) !== undefined; counter++) option[name].bind = value;
             }
         });
-    });
+    }
+    defineOptionMember("text");
+    defineOptionMember("value");
     function removeOption(index)
     {
         var option  = this.__options[index];

--- a/AtomicJS/src/atomic/scripts/html/viewAdapterFactory.js
+++ b/AtomicJS/src/atomic/scripts/html/viewAdapterFactory.js
@@ -1,4 +1,4 @@
-!function(){"use strict";root.define("atomic.html.viewAdapterFactory", function htmlViewAdapterFactory(document, controlTypes, pubSub, logger, each)
+!function(){"use strict";root.define("atomic.html.viewAdapterFactory", function htmlViewAdapterFactory(document, controlTypes, pubSub, logger, reflect)
 {
     function loadACU(url, controlUnitFullName, callback)
     {
@@ -68,20 +68,24 @@
                 var viewElement                     = viewElementTemplate.cloneNode(true);
                 if (containerElement !== undefined)
                 {
-                    container                       = this.create
-                    ({
-                        definitionConstructor:  function(){return {};}, 
-                        initializerDefinition:  {},
-                        viewElement:            containerElement,
-                        parent:                 parent,
-                        selector:               selector,
-                        controlKey:             controlKey,
-                        protoControlKey:        protoControlKey,
-                        controlType:            "panel",
-                        bindPath:               bindPath
-                    });
-                    containerElement.innerHTML   = "";
-                    containerElement.appendChild(viewElement);
+                    if (initializerDefinition.replaceElement)   containerElement.parentNode.replaceChild(viewElement, containerElement);
+                    else
+                    {
+                        container                       = this.create
+                        ({
+                            definitionConstructor:  function(){return {};}, 
+                            initializerDefinition:  {},
+                            viewElement:            containerElement,
+                            parent:                 parent,
+                            selector:               selector,
+                            controlKey:             controlKey,
+                            protoControlKey:        protoControlKey,
+                            controlType:            "panel",
+                            bindPath:               bindPath
+                        });
+                        containerElement.innerHTML   = "";
+                        containerElement.appendChild(viewElement);
+                    }
                 }
                 else                                parent.__setViewData("appendChild", viewElement);
 
@@ -112,6 +116,7 @@
                 viewElement         = document.body;
             }
             if (callback === undefined)             callback    = function(adapter){adapter.__getData()("", {});};
+            else if(callback.isObserver)            callback    = (function(data){return function(adapter){adapter.__setData(data);};})(callback);
             else if(typeof callback === "object")   callback    = (function(data){return function(adapter){adapter.data("", data);};})(callback);
             var adapter =
             this.createView

--- a/AtomicJS/src/atomic/scripts/observerFactory.js
+++ b/AtomicJS/src/atomic/scripts/observerFactory.js
@@ -232,7 +232,7 @@
                     var virtualProperty = {cachedValues: {}};
                     if (property.get !== undefined) virtualProperty.get = (function(basePath, key)
                     {
-                        var path = basePath + ((basePath||"").length > 0 && (key||"").length > 0 ? "[\'" : "") + key.replace("'", "\\'") + ((basePath||"").length > 0 && (key||"").length > 0 ? "']" : "");
+                        var path = basePath + ((basePath||"").length > 0 && (key||"").length > 0 ? "." : "") + key;
                         if (virtualProperty.cachedValues[path] === undefined)
                         {
                             virtualProperty.cachedValues[path]  = { listener: (function()

--- a/AtomicJS/src/atomic/scripts/observerFactory.js
+++ b/AtomicJS/src/atomic/scripts/observerFactory.js
@@ -218,6 +218,7 @@
             observe:            {value: function(path, peek){return this.__invoke(path, undefined, getObserverEnum.yes, peek);}},
             peek:               {value: function(path, unwrap){return this.__invoke(path, undefined, unwrap === true ? getObserverEnum.no : getObserverEnum.auto, true);}},
             read:               {value: function(path, peek){return this.__invoke(path, undefined, getObserverEnum.auto, peek);}},
+            toggle:             {value: function(path, value){this.setValue(path, this(path) == value ? undefined : value, false); }},
             unwrap:             {value: function(path){return this.__invoke(path, undefined, getObserverEnum.no, false);}},
             basePath:           {value: function(){return this.__basePath;}},
             shadows:            {get:   function(){return this.__bag.shadows;}},

--- a/AtomicJS/src/atomic/scripts/observerFactory.js
+++ b/AtomicJS/src/atomic/scripts/observerFactory.js
@@ -232,7 +232,7 @@
                     var virtualProperty = {cachedValues: {}};
                     if (property.get !== undefined) virtualProperty.get = (function(basePath, key)
                     {
-                        var path = basePath + ((basePath||"").length > 0 && (key||"").length > 0 ? "." : "") + key;
+                        var path = basePath + ((basePath||"").length > 0 && (key||"").length > 0 ? "[\'" : "") + key.replace("'", "\\'") + ((basePath||"").length > 0 && (key||"").length > 0 ? "']" : "");
                         if (virtualProperty.cachedValues[path] === undefined)
                         {
                             virtualProperty.cachedValues[path]  = { listener: (function()

--- a/AtomicJS/src/atomic/scripts/observerFactory.js
+++ b/AtomicJS/src/atomic/scripts/observerFactory.js
@@ -1,7 +1,7 @@
 !function()
 {"use strict";
     var createObserver;
-    function buildConstructor(removeFromArray, isolatedFunctionFactory, each, pathParser)
+    function buildConstructor(removeFromArray, isolatedFunctionFactory, reflect, pathParser)
     {
         var getObserverEnum                             = {auto: 0, no: -1, yes: 1};
         var objectObserverFunctionFactory               = new isolatedFunctionFactory();
@@ -185,7 +185,7 @@
             var paths   = Object.keys(virtualProperty.cachedValues);
             for(var pathCounter=paths.length-1,path;(path=paths[pathCounter--]) !== undefined;) this.ignore(virtualProperty.cachedValues[path].listener);
         }
-        each([objectObserverFunctionFactory,arrayObserverFunctionFactory],function(functionFactory){Object.defineProperties(functionFactory.root.prototype,
+        function decorateFunctionFactory(functionFactory){Object.defineProperties(functionFactory.root.prototype,
         {
             __invoke:           {value: function(path, value, getObserver, peek, forceSet, silentUpdate)
             {
@@ -436,8 +436,10 @@
 
                 childObserver.unlink(childRootPath, this, rootPath, true);
             }}
-        });});
-        each(["push","pop","shift","unshift","sort","reverse","splice"], function(name)
+        });}
+        decorateFunctionFactory(objectObserverFunctionFactory);
+        decorateFunctionFactory(arrayObserverFunctionFactory);
+        function addArrayMembers(name)
         {
             Object.defineProperty
             (
@@ -456,8 +458,12 @@
                     }
                 }
             );
-        });
-        each(["remove","removeAll","move","swap"], function(name)
+        }
+        var members = ["push","pop","shift","unshift","sort","reverse","splice"];
+        for(var counter=0,member;(member=members[counter]) !== undefined; counter++)   addArrayMembers(member);
+
+        members     = ["remove","removeAll","move","swap"];
+        function addArrayMembers2(name)
         {
             Object.defineProperty
             (
@@ -475,8 +481,11 @@
                     }
                 }
             );
-        });
-        each(["join","indexOf","slice"], function(name)
+        }
+        for(var counter=0,member;(member=members[counter]) !== undefined; counter++)   addArrayMembers2(member);
+
+        members     = ["join","indexOf","slice"];
+        function addArrayMembers3(name)
         {
             Object.defineProperty
             (
@@ -490,7 +499,9 @@
                     }
                 }
             );
-        });
+        }
+        for(var counter=0,member;(member=members[counter]) !== undefined; counter++)   addArrayMembers3(member);
+
         Object.defineProperties(arrayObserverFunctionFactory.root.prototype,
         {
             __move:             {value: function(value, toIndex)
@@ -544,9 +555,9 @@
         });
         return createObserver;
     }
-    root.define("atomic.observerFactory", function(removeFromArray, isolatedFunctionFactory, each, pathParser)
+    root.define("atomic.observerFactory", function(removeFromArray, isolatedFunctionFactory, reflect, pathParser)
     {
-        if (createObserver === undefined)  createObserver   = buildConstructor(removeFromArray, isolatedFunctionFactory, each, pathParser);
+        if (createObserver === undefined)  createObserver   = buildConstructor(removeFromArray, isolatedFunctionFactory, reflect, pathParser);
         return function observer(_item)
         {
             var bag             =

--- a/AtomicJS/src/atomic/scripts/pathParserFactory.js
+++ b/AtomicJS/src/atomic/scripts/pathParserFactory.js
@@ -45,7 +45,7 @@
     function wordTokenizer()
     {
         var firstLetterCharacters   = /[a-zA-Z_$]/;
-        var wordCharacters          = /[a-zA-Z0-9_$]/;
+        var wordCharacters          = /[a-zA-Z0-9_\-$]/;
         var priv                    =
         {
             value:  ""

--- a/AtomicJS/src/atomic/scripts/pathParserFactory.js
+++ b/AtomicJS/src/atomic/scripts/pathParserFactory.js
@@ -44,7 +44,6 @@
     Object.defineProperty(stringLiteralTokenizer, "prototype", {value: Object.create(tokenizer.prototype)});
     function wordTokenizer()
     {
-        var firstLetterCharacters   = /[a-zA-Z_$]/;
         var wordCharacters          = /[a-zA-Z0-9_\-$]/;
         var priv                    =
         {
@@ -55,16 +54,11 @@
         function read(currentChar)
         {
             var handled = false;
-            if (!prot.isClosed && wordCharacters.test(currentChar))
+            if (wordCharacters.test(currentChar))
             {
+                if (prot.isClosed)  prot.isClosed   = false;
                 priv.value  += currentChar;
                 handled     = true;
-            }
-            else if (prot.isClosed && firstLetterCharacters.test(currentChar))
-            {
-                prot.isClosed   = false;
-                priv.value      = currentChar;
-                handled         = true;
             }
             return handled;
         }
@@ -404,8 +398,8 @@
                 new stringLiteralTokenizer("'", true),
                 new stringLiteralTokenizer("\"", true),
                 new stringLiteralTokenizer("`", false),
-                new wordTokenizer(),
                 new numeralTokenizer(),
+                new wordTokenizer(),
                 new delimiterTokenizer('.', propertyDelimiter),
                 new operatorTokenizer("...", ROOTDIRECTIVE),
                 new delimiterTokenizer('[', openKeyDelimiter),

--- a/AtomicJS/src/atomic/scripts/pathParserFactory.js
+++ b/AtomicJS/src/atomic/scripts/pathParserFactory.js
@@ -45,7 +45,7 @@
     function wordTokenizer()
     {
         var firstLetterCharacters   = /[a-zA-Z_$]/;
-        var wordCharacters          = /[a-zA-Z0-9_\-$]/;
+        var wordCharacters          = /[a-zA-Z0-9_$]/;
         var priv                    =
         {
             value:  ""


### PR DESCRIPTION
Improved performance up to 10% to 20% for some repeater laden applications by switching to for loops instead of using the each function.  Fixed several bugs including property forwarding.  Introduced reflect.deleteProperty and reflect.deleteProperties utility functions.  Fixed a bug where changing the bindPath of a container would not propogate the change to its child controls.  Improved performance of hierarchical control tree destroy calls.